### PR TITLE
bugfix/ React-native-paper em darkmode

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -30,6 +30,7 @@ import ActivitiesDate from "./screens/ActivitiesDate";
 import Login from "./screens/Login";
 import CalendarScreen from "./screens/CalendarScreen";
 import Welcome from "./screens/Welcome";
+import { PaperProvider, MD3DarkTheme as PaperDarkMode } from "react-native-paper";
 
 const Stack = createNativeStackNavigator();
 
@@ -57,40 +58,42 @@ export default function App() {
   return (
     <>
       <StatusBar style="light" />
-      <UserProvider>
-        <NavigationContainer>
-          <Stack.Navigator
-            screenOptions={{ headerShown: false, animation: "none" }}
-          >
-            <Stack.Screen name="Verification" component={Verification} />
-            <Stack.Screen name="Home" component={Home} />
+      <PaperProvider theme={PaperDarkMode}>
+        <UserProvider>
+          <NavigationContainer>
+            <Stack.Navigator
+              screenOptions={{ headerShown: false, animation: "none" }}
+            >
+              <Stack.Screen name="Verification" component={Verification} />
+              <Stack.Screen name="Home" component={Home} />
 
-            <Stack.Screen name="Week" component={Week} />
-            <Stack.Screen name="Calendar" children={CalendarScreen} />
+              <Stack.Screen name="Week" component={Week} />
+              <Stack.Screen name="Calendar" children={CalendarScreen} />
 
-            <Stack.Screen name="Starter" component={Starter} />
-            <Stack.Screen name="Login" component={Login} />
-            <Stack.Screen name="Welcome" component={Welcome} />
+              <Stack.Screen name="Starter" component={Starter} />
+              <Stack.Screen name="Login" component={Login} />
+              <Stack.Screen name="Welcome" component={Welcome} />
 
-            <Stack.Screen name="Activities" component={Activities} />
-            <Stack.Screen name="ActivitiesDate" component={ActivitiesDate} />
-            <Stack.Screen name="CreateActivity" component={CreateActivity} />
+              <Stack.Screen name="Activities" component={Activities} />
+              <Stack.Screen name="ActivitiesDate" component={ActivitiesDate} />
+              <Stack.Screen name="CreateActivity" component={CreateActivity} />
 
-            <Stack.Screen name="Absences" component={Absences} />
-            <Stack.Screen name="AbsenceList" component={AbsenceList} />
+              <Stack.Screen name="Absences" component={Absences} />
+              <Stack.Screen name="AbsenceList" component={AbsenceList} />
 
-            <Stack.Screen name="Grade" component={Grade} />
-            <Stack.Screen name="GradeList" component={GradeList} />
+              <Stack.Screen name="Grade" component={Grade} />
+              <Stack.Screen name="GradeList" component={GradeList} />
 
-            <Stack.Screen name="Groups" component={Groups} />
-            <Stack.Screen name="Group" component={Group} />
+              <Stack.Screen name="Groups" component={Groups} />
+              <Stack.Screen name="Group" component={Group} />
 
-            <Stack.Screen name="Settings" component={Settings} />
-            <Stack.Screen name="Contact" component={Contact} />
-          </Stack.Navigator>
-        </NavigationContainer>
-        <Toast />
-      </UserProvider>
+              <Stack.Screen name="Settings" component={Settings} />
+              <Stack.Screen name="Contact" component={Contact} />
+            </Stack.Navigator>
+          </NavigationContainer>
+          <Toast />
+        </UserProvider>
+      </PaperProvider>
     </>
   );
 }

--- a/components/DateInput/index.tsx
+++ b/components/DateInput/index.tsx
@@ -3,7 +3,8 @@ import DateTimePickerModal from "react-native-modal-datetime-picker";
 import theme from "../../config/theme";
 import React, { useState } from "react";
 import getActivityDate from "../../utils/getActivityDate";
-import { DatePickerModal } from "react-native-paper-dates";
+import { pt } from "react-native-paper-dates";
+import { DatePickerModal, registerTranslation } from "react-native-paper-dates";
 import { Platform } from "react-native";
 
 const DateInputContainer = styled.TouchableOpacity`
@@ -21,6 +22,7 @@ const DateInputText = styled.Text`
   font-size: 16px;
   color: #fff;
 `;
+
 interface DateInputProps {
   value?: Date;
   style?: any;
@@ -48,7 +50,9 @@ const DateInput = ({
     onChangeValue(result.date);
     hideDatePicker();
   };
-
+  
+  registerTranslation("pt", pt); // Para o DatePickerModal
+  
   return (
     <>
       <DateInputContainer style={style} onPress={showDatePicker}>
@@ -63,7 +67,7 @@ const DateInput = ({
 
       {Platform.OS === "web" ? (
         <DatePickerModal
-          locale="pt"
+          locale= "pt"
           mode="single"
           visible={isDatePickerVisible}
           onDismiss={hideDatePicker}


### PR DESCRIPTION
**Problema:**
- Antes o calendário aparecia em whiteMode no web

**Ajuste:**
- O que aconteceu foi que o React Native Paper, usado para colocar o calendário, estava sem definição de thema, assim na app.tsx foi adicionado o  PaperProvider com theme darkMode, agora sempre que algum item do Paper for utilizado, ele estará nativamente em darkMode.

- Agora tudo que envolve o React Native Paper estará em DarkMode

**VERIFICAR**
- Devido a expo issue >.< não  consigo testar no mobile para ver se nada ficou incorreto, se puderem rever ai...
- Coloquei o Provider do paper direto na app.tsx, não sei se é uma implicação que atrapalha alguma coisa...

![image](https://github.com/user-attachments/assets/6d2c991e-9ca1-4707-8643-3aca08086cb2)
