### PR TITLE
refactor: unify calendar components

### DIFF
--- a/components/CalendarComponent/index.tsx
+++ b/components/CalendarComponent/index.tsx
@@ -5,7 +5,6 @@ import { MaterialIcons } from "@expo/vector-icons";
 import { CalendarList, DateData, LocaleConfig } from "react-native-calendars";
 import theme from "../../config/theme";
 import { useUser } from "../../contexts/UserContext";
-import { SafeAreaView } from "react-native-safe-area-context";
 import getActivityColorByType from "../../utils/getActivityColorByType";
 import getImportantColorByType from "../../utils/getImportantColorByType";
 import parseUTCDate from "../../utils/parseUTCDate";
@@ -64,63 +63,52 @@ const CalendarComponent: React.FC<Props> = ({ onDayPress }: Props) => {
   const [currentDate] = useState(() => {
     const now = new Date();
     const year = now.getFullYear();
-    const month = String(now.getMonth() + 1).padStart(2, '0');
-    const day = String(now.getDate()).padStart(2, '0');
+    const month = String(now.getMonth() + 1).padStart(2, "0");
+    const day = String(now.getDate()).padStart(2, "0");
     return `${year}-${month}-${day}`;
   });
 
   const updateList = () => {
-    const markedDates: any = {};
+    const newMarkedDates: any = {};
 
-    const activeActivities = userActivities.filter(
-      (activity) => !activity.deletedAt
-    );
+    const addDot = (date: string, color: string) => {
+      const dot = { marked: true, color };
 
-    activeActivities.forEach((activity) => {
-      const obj = {
-        marked: true,
-        color: getActivityColorByType(activity.type),
-      };
-
-      const activityDate = parseUTCDate(activity.finishDate);
-
-      const year = activityDate.getFullYear();
-      const month = String(activityDate.getMonth() + 1).padStart(2, "0");
-      const day = String(activityDate.getDate()).padStart(2, "0");
-
-      const date = `${year}-${month}-${day}`;
-
-      if (!markedDates[date]) {
-        markedDates[date] = { dots: [obj] };
+      if (!newMarkedDates[date]) {
+        newMarkedDates[date] = { dots: [dot] };
         return;
       }
 
-      markedDates[date].dots.push(obj);
-    });
+      newMarkedDates[date].dots.push(dot);
+    };
+
+    userActivities
+      .filter((activity) => !activity.deletedAt)
+      .forEach((activity) => {
+        const activityDate = parseUTCDate(activity.finishDate);
+        const year = activityDate.getFullYear();
+        const month = String(activityDate.getMonth() + 1).padStart(2, "0");
+        const day = String(activityDate.getDate()).padStart(2, "0");
+
+        addDot(
+          `${year}-${month}-${day}`,
+          getActivityColorByType(activity.type),
+        );
+      });
 
     importantDates.forEach((importantDate) => {
-      const obj = {
-        marked: true,
-        color: getImportantColorByType(importantDate.type),
-      };
-
       const importantDateObj = parseUTCDate(importantDate.date);
-
       const year = importantDateObj.getFullYear();
       const month = String(importantDateObj.getMonth() + 1).padStart(2, "0");
       const day = String(importantDateObj.getDate()).padStart(2, "0");
 
-      const dateFormatted = `${year}-${month}-${day}`;
-
-      if (!markedDates[dateFormatted]) {
-        markedDates[dateFormatted] = { dots: [obj] };
-        return;
-      }
-
-      markedDates[dateFormatted].dots.push(obj);
+      addDot(
+        `${year}-${month}-${day}`,
+        getImportantColorByType(importantDate.type),
+      );
     });
 
-    setMarkedDates(markedDates);
+    setMarkedDates(newMarkedDates);
   };
 
   useEffect(() => {
@@ -129,11 +117,8 @@ const CalendarComponent: React.FC<Props> = ({ onDayPress }: Props) => {
 
   const isWebVersion = Platform.OS === "web";
 
-  console.log('Current date for calendar:', currentDate);
-
   return (
-    // @ts-ignore
-    <SafeAreaView style={{ flex: 1 }}>
+    <View style={{ flex: 1 }}>
       <CalendarList
         key={`${currentDate}-${JSON.stringify(markedDates)}`}
         current={currentDate}
@@ -175,7 +160,7 @@ const CalendarComponent: React.FC<Props> = ({ onDayPress }: Props) => {
           },
         }}
       />
-    </SafeAreaView>
+    </View>
   );
 };
 

--- a/components/CalendarModel/index.tsx
+++ b/components/CalendarModel/index.tsx
@@ -1,64 +1,12 @@
 // ts-nocheck
-import React, { useEffect, useState } from "react";
-import {
-  Dimensions,
-  Platform,
-  TouchableOpacity,
-  View,
-} from "react-native";
+import React from "react";
+import { TouchableOpacity, View } from "react-native";
 import { MaterialIcons } from "@expo/vector-icons";
-import { CalendarList, DateData, LocaleConfig } from "react-native-calendars";
-import theme from "../../config/theme";
-import { useUser } from "../../contexts/UserContext";
+import { DateData } from "react-native-calendars";
 import styles from "./styles";
 import { SafeAreaView } from "react-native-safe-area-context";
-import getActivityColorByType from "../../utils/getActivityColorByType";
-import parseUTCDate from "../../utils/parseUTCDate";
 import Title from "../Title";
-
-LocaleConfig.locales["pt"] = {
-  monthNames: [
-    "Janeiro",
-    "Fevereiro",
-    "Março",
-    "Abril",
-    "Maio",
-    "Junho",
-    "Julho",
-    "Agosto",
-    "Setembro",
-    "Outubro",
-    "Novembro",
-    "Dezembro",
-  ],
-  monthNamesShort: [
-    "Jan",
-    "Fev",
-    "Mar",
-    "Abr",
-    "Mai",
-    "Jun",
-    "Jul",
-    "Ago",
-    "Set",
-    "Out",
-    "Nov",
-    "Dez",
-  ],
-  dayNames: [
-    "Domingo",
-    "Segunda",
-    "Terça",
-    "Quarta",
-    "Quinta",
-    "Sexta",
-    "Sábado",
-  ],
-  dayNamesShort: ["Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sab"],
-  today: "Hoje",
-};
-
-LocaleConfig.defaultLocale = "pt";
+import CalendarComponent from "../CalendarComponent";
 
 interface Props {
   onDayPress: (date: DateData) => void;
@@ -71,48 +19,6 @@ const CalendarModal: React.FC<Props> = ({
   onDayPress,
   onClose,
 }: Props) => {
-  const { userActivities } = useUser();
-  const [markedDates, setMarkedDates] = useState({});
-
-  const updateList = () => {
-    const markedDates: any = {};
-
-    const activeActivities = userActivities.filter(
-      (activity) => !activity.deletedAt
-    );
-
-    activeActivities.forEach((activity) => {
-      const obj = {
-        marked: true,
-        color: getActivityColorByType(activity.type),
-      };
-
-      const activityDate = parseUTCDate(activity.finishDate);
-
-      const year = activityDate.getFullYear();
-      const month = String(activityDate.getMonth() + 1).padStart(2, "0");
-      const day = String(activityDate.getDate()).padStart(2, "0");
-
-      const date = `${year}-${month}-${day}`;
-
-      if (!markedDates[date]) {
-        markedDates[date] = { dots: [obj] };
-        return;
-      }
-
-      markedDates[date].dots.push(obj);
-    });
-
-    console.log("Marked dates:", markedDates);
-    setMarkedDates(markedDates);
-  };
-
-  useEffect(() => {
-    updateList();
-  }, [userActivities]);
-
-  const isWebVersion = Platform.OS === "web";
-
   return (
     // @ts-ignore
     <SafeAreaView style={[styles.container, { paddingTop }]}>
@@ -134,47 +40,10 @@ const CalendarModal: React.FC<Props> = ({
           <MaterialIcons name="arrow-back" size={28} color="white" />
         </TouchableOpacity>
 
-        <Title style={{ marginBottom: 0 }}>
-          Atividades
-        </Title>
+        <Title style={{ marginBottom: 0 }}>Atividades</Title>
       </View>
 
-      <CalendarList
-        key={JSON.stringify(markedDates)}
-        horizontal={true}
-        style={{ width: Dimensions.get("window").width }}
-        markedDates={markedDates}
-        markingType={"multi-dot"}
-        onDayPress={onDayPress}
-        calendarHeight={Dimensions.get("window").height - 68 - 83}
-        calendarWidth={Dimensions.get("window").width}
-        hideArrows={!isWebVersion}
-        renderArrow={(direction: string) =>
-          direction === "left" ? (
-            <MaterialIcons name="chevron-left" size={24} color="white" />
-          ) : (
-            <MaterialIcons name="chevron-right" size={24} color="white" />
-          )
-        }
-        theme={{
-          backgroundColor: theme.colors.gray.gray1,
-          calendarBackground: theme.colors.gray.gray1,
-          todayTextColor: "#3FA14C",
-          dayTextColor: "white",
-          monthTextColor: "white",
-          textDayFontFamily: "Montserrat_400Regular",
-          textDayFontSize: 20,
-          textMonthFontFamily: "Montserrat_700Bold",
-          // @ts-ignore
-          "stylesheet.day.basic": {
-            base: {
-              height: (Dimensions.get("window").height - 68 - 83 - 160) / 6,
-              alignItems: "center",
-              justifyContent: "center",
-            },
-          },
-        }}
-      />
+      <CalendarComponent onDayPress={onDayPress} />
     </SafeAreaView>
   );
 };


### PR DESCRIPTION
## What changed

- Reused a single calendar component for both the main Calendar screen and the Activities calendar.
- Removed duplicated calendar logic from `CalendarModel`.
- Centralized activity and important date markings in `CalendarComponent`.
- Centralized calendar styling, paging, arrows, and theme configuration.
- Kept `CalendarModel` responsible only for the Activities-specific header and close behavior.

## Why

The app had two separate calendar implementations with almost identical logic.

This caused inconsistencies between them, such as:
- important dates appearing only in the main calendar;
- paging behavior being different between calendars;
- fixes having to be applied in two different places.

With this refactor, calendar behavior is now maintained in a single component, reducing duplication and preventing the two calendars from diverging again.

## Files changed

- `components/CalendarComponent/index.tsx`
- `components/CalendarModel/index.tsx`

## Testing

- Opened the main Calendar screen.
- Opened the calendar from Activities.
- Verified horizontal month navigation.
- Verified activity markers.
- Verified important date markers.
- Verified day selection in both calendars.
- Verified the Activities calendar back button.